### PR TITLE
feat: Add QUIC address validation with in-memory cache

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -19,6 +19,7 @@ jobs:
 
       - name: Update dependencies to latest commits
         run: |
+          go get -u github.com/dgraph-io/ristretto/v2@main
           go get -u github.com/miekg/dns@master
           go get -u github.com/redis/go-redis/v9@master
           go get -u github.com/quic-go/quic-go@master

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module zjdns
 go 1.25.1
 
 require (
+	github.com/dgraph-io/ristretto/v2 v2.3.0
 	github.com/miekg/dns v1.1.69-0.20250920065150-294d37389ccc
 	github.com/quic-go/quic-go v0.54.1-0.20250924105422-97f3aae7760a
 	github.com/redis/go-redis/v9 v9.16.0-beta.1.0.20250929063504-3ad9f9cb2334
@@ -12,6 +13,7 @@ require (
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
+	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/quic-go/qpack v0.5.1 // indirect
 	go.uber.org/mock v0.6.0 // indirect
 	golang.org/x/crypto v0.42.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module zjdns
 go 1.25.1
 
 require (
-	github.com/dgraph-io/ristretto/v2 v2.3.0
+	github.com/dgraph-io/ristretto/v2 v2.3.1-0.20250905144517-ebc181521755
 	github.com/miekg/dns v1.1.69-0.20250920065150-294d37389ccc
 	github.com/quic-go/quic-go v0.54.1-0.20250924105422-97f3aae7760a
 	github.com/redis/go-redis/v9 v9.16.0-beta.1.0.20250929063504-3ad9f9cb2334

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,14 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgraph-io/ristretto/v2 v2.3.0 h1:qTQ38m7oIyd4GAed/QkUZyPFNMnvVWyazGXRwvOt5zk=
+github.com/dgraph-io/ristretto/v2 v2.3.0/go.mod h1:gpoRV3VzrEY1a9dWAYV6T1U7YzfgttXdd/ZzL1s9OZM=
+github.com/dgryski/go-farm v0.0.0-20240924180020-3414d57e47da h1:aIftn67I1fkbMa512G+w+Pxci9hJPB8oMnkcP3iZF38=
+github.com/dgryski/go-farm v0.0.0-20240924180020-3414d57e47da/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
+github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
+github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/miekg/dns v1.1.69-0.20250920065150-294d37389ccc h1:hBFUTIJViiANS9sSTdXza7R8RgpksG6Hx6xkjBcuSkA=
@@ -20,8 +26,8 @@ github.com/quic-go/quic-go v0.54.1-0.20250924105422-97f3aae7760a h1:1pBwhkWYQUcF
 github.com/quic-go/quic-go v0.54.1-0.20250924105422-97f3aae7760a/go.mod h1:DR51ilwU1uE164KuWXhinFcKWGlEjzys2l8zUl5Ss1U=
 github.com/redis/go-redis/v9 v9.16.0-beta.1.0.20250929063504-3ad9f9cb2334 h1:i9uiSg3RPubiYGknv6zvNEFyFfILMzc4MUx94Gw8dNs=
 github.com/redis/go-redis/v9 v9.16.0-beta.1.0.20250929063504-3ad9f9cb2334/go.mod h1:u410H11HMLoB+TP67dz8rL9s6QW2j76l0//kSOd3370=
-github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
-github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 go.uber.org/mock v0.6.0 h1:hyF9dfmbgIX5EfOdasqLsWD6xqpNZlXblLB/Dbnwv3Y=
 go.uber.org/mock v0.6.0/go.mod h1:KiVJ4BqZJaMj4svdfmHM0AUx4NJYO8ZNpPnZn1Z+BBU=
 golang.org/x/crypto v0.42.0 h1:chiH31gIWm57EkTXpwnqf8qeuMUi0yekh6mT2AvFlqI=

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgraph-io/ristretto/v2 v2.3.0 h1:qTQ38m7oIyd4GAed/QkUZyPFNMnvVWyazGXRwvOt5zk=
-github.com/dgraph-io/ristretto/v2 v2.3.0/go.mod h1:gpoRV3VzrEY1a9dWAYV6T1U7YzfgttXdd/ZzL1s9OZM=
+github.com/dgraph-io/ristretto/v2 v2.3.1-0.20250905144517-ebc181521755 h1:nG/CXiMDT/GcF9CIqVHIHF7oXRjG9NDSWzkdw7HNF+M=
+github.com/dgraph-io/ristretto/v2 v2.3.1-0.20250905144517-ebc181521755/go.mod h1:gpoRV3VzrEY1a9dWAYV6T1U7YzfgttXdd/ZzL1s9OZM=
 github.com/dgryski/go-farm v0.0.0-20240924180020-3414d57e47da h1:aIftn67I1fkbMa512G+w+Pxci9hJPB8oMnkcP3iZF38=
 github.com/dgryski/go-farm v0.0.0-20240924180020-3414d57e47da/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=

--- a/main.go
+++ b/main.go
@@ -505,6 +505,7 @@ type (
 		}
 	}
 
+	// QuicAddrValidator validates QUIC addresses
 	QuicAddrValidator struct {
 		cache *ristretto.Cache[string, string]
 		ttl   time.Duration

--- a/main.go
+++ b/main.go
@@ -5934,6 +5934,7 @@ func (tm *TLSManager) Shutdown() error {
 	}
 	if tm.quicAddrValidator != nil {
 		tm.quicAddrValidator.Close()
+		Debug("QUIC address validator closed")
 	}
 
 	if tm.httpsServer != nil {

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/dgraph-io/ristretto/v2"
 	"github.com/miekg/dns"
 	"github.com/quic-go/quic-go"
 	"github.com/quic-go/quic-go/http3"
@@ -135,6 +136,10 @@ const (
 	TCPWriteBufferSize = 128 * 1024
 	TCPNoDelay         = 1
 	TCPQuickAck        = 0x0c // Linux TCP_QUICKACK
+
+	// QUIC Address Validation Configuration
+	QUICAddrValidatorCacheSize = 10000
+	QUICAddrValidatorTTL       = 300 * time.Second
 
 	// Default Values
 	DefaultLogLevel = "info"
@@ -454,25 +459,31 @@ type (
 		closed        bool
 		mu            sync.RWMutex
 	}
+
+	QuicAddrValidator struct {
+		cache *ristretto.Cache[string, string]
+		ttl   time.Duration
+	}
 )
 
 // Security & Management Types
 type (
 	// TLSManager handles secure DNS protocols (DoT/DoH/DoQ)
 	TLSManager struct {
-		server        *DNSServer
-		tlsConfig     *tls.Config
-		ctx           context.Context
-		cancel        context.CancelFunc
-		wg            sync.WaitGroup
-		tlsListener   net.Listener
-		quicConn      *net.UDPConn
-		quicListener  *quic.EarlyListener
-		quicTransport *quic.Transport
-		httpsServer   *http.Server
-		h3Server      *http3.Server
-		httpsListener net.Listener
-		h3Listener    *quic.EarlyListener
+		server            *DNSServer
+		tlsConfig         *tls.Config
+		ctx               context.Context
+		cancel            context.CancelFunc
+		wg                sync.WaitGroup
+		tlsListener       net.Listener
+		quicConn          *net.UDPConn
+		quicListener      *quic.EarlyListener
+		quicTransport     *quic.Transport
+		quicAddrValidator *QuicAddrValidator
+		httpsServer       *http.Server
+		h3Server          *http3.Server
+		httpsListener     net.Listener
+		h3Listener        *quic.EarlyListener
 	}
 
 	// UpstreamManager manages upstream DNS servers
@@ -5195,11 +5206,18 @@ func NewTLSManager(server *DNSServer, config *ServerConfig) (*TLSManager, error)
 
 	ctx, cancel := context.WithCancel(context.Background())
 
+	quicAddrValidator, err := NewQUICAddrValidator(QUICAddrValidatorCacheSize, QUICAddrValidatorTTL)
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("failed to create QUIC address validator: %w", err)
+	}
+
 	return &TLSManager{
-		server:    server,
-		tlsConfig: tlsConfig,
-		ctx:       ctx,
-		cancel:    cancel,
+		server:            server,
+		tlsConfig:         tlsConfig,
+		ctx:               ctx,
+		cancel:            cancel,
+		quicAddrValidator: quicAddrValidator,
 	}, nil
 }
 
@@ -5298,7 +5316,8 @@ func (tm *TLSManager) StartQUICServer() error {
 	}
 
 	tm.quicTransport = &quic.Transport{
-		Conn: tm.quicConn,
+		Conn:                tm.quicConn,
+		VerifySourceAddress: tm.quicAddrValidator.RequiresValidation,
 	}
 
 	quicTLSConfig := tm.tlsConfig.Clone()
@@ -5830,6 +5849,47 @@ func (tm *TLSManager) IsQUICErrorForDebugLog(err error) bool {
 	return errors.As(err, &qIdleErr)
 }
 
+// NewQUICAddrValidator initializes a new instance of *QuicAddrValidator.
+func NewQUICAddrValidator(cacheSize int, ttl time.Duration) (v *QuicAddrValidator, err error) {
+	cache, err := ristretto.NewCache(&ristretto.Config[string, string]{
+		NumCounters: int64(cacheSize * 10), // Recommended to set it as 10 times the MaxCost
+		MaxCost:     int64(cacheSize),
+		BufferItems: 64,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("creating ristretto cache: %w", err)
+	}
+
+	return &QuicAddrValidator{
+		cache: cache,
+		ttl:   ttl,
+	}, nil
+}
+
+// RequiresValidation determines if a QUIC Retry packet should be sent by the
+// client. This allows the server to verify the client's address but increases
+// the latency.
+func (v *QuicAddrValidator) RequiresValidation(addr net.Addr) (ok bool) {
+	// addr must be *net.UDPAddr here and if it's not we don't mind panic.
+	key := addr.(*net.UDPAddr).IP.String()
+
+	if _, found := v.cache.Get(key); found {
+		return false
+	}
+
+	// Setting cost to 1 means it occupies 1 cache slot
+	v.cache.SetWithTTL(key, "true", 1, v.ttl)
+
+	// Address not found in the cache so return true to make sure the server
+	// will require address validation.
+	return true
+}
+
+// Close 关闭缓存
+func (v *QuicAddrValidator) Close() {
+	v.cache.Close()
+}
+
 // ReadAll reads all data from reader
 func (tm *TLSManager) ReadAll(r io.Reader, buf []byte) (int, error) {
 	var n int
@@ -5871,6 +5931,9 @@ func (tm *TLSManager) Shutdown() error {
 		if closeErr := tm.quicConn.Close(); closeErr != nil {
 			Debug("Closing QUIC connection failed: %v", closeErr)
 		}
+	}
+	if tm.quicAddrValidator != nil {
+		tm.quicAddrValidator.Close()
 	}
 
 	if tm.httpsServer != nil {


### PR DESCRIPTION
## Sourcery 总结

添加一个 QUIC 地址验证机制，使用内存缓存来跟踪已验证的客户端地址，并将其集成到 QUIC 传输设置中。

新功能：
- 引入 QuicAddrValidator 类型，带有 Ristretto 缓存和 TTL，用于记录和管理已验证的客户端 IP
- 将 QuicAddrValidator 集成到 TLSManager 中，为 QUIC 连接设置 Transport.VerifySourceAddress，并在关闭时关闭缓存

构建：
- 添加 github.com/dgraph-io/ristretto/v2 依赖，用于地址验证器缓存

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a QUIC address validation mechanism using an in-memory cache to track validated client addresses and integrate it into the QUIC transport setup.

New Features:
- Introduce QuicAddrValidator type with a Ristretto cache and TTL to record and manage validated client IPs
- Integrate QuicAddrValidator into TLSManager to set Transport.VerifySourceAddress for QUIC connections and close the cache on shutdown

Build:
- Add github.com/dgraph-io/ristretto/v2 dependency for the address validator cache

</details>