### PR TITLE
feat: Implement intelligent root server management

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 ### 🔧 核心功能
 
 - **递归 DNS 解析**：完整实现 DNS 递归查询算法，从根服务器开始逐级解析
+- **智能根服务器管理**：自动管理 13 个 IPv4 和 13 个 IPv6 根服务器，基于实时网络延迟测试进行动态排序，优先选择最优服务器进行查询
 - **智能协议协商**：同时支持 UDP 和 TCP 协议，**当 UDP 响应被截断或超过缓冲区大小时，自动回退到 TCP 协议**，确保大响应数据的完整传输
 - **CNAME 链解析**：智能处理 CNAME 记录链，防止循环引用，支持多级 CNAME 解析
 - **并发查询**：高性能并发处理，支持连接池管理
@@ -97,6 +98,7 @@ graph TD
         D --> F[ConnectionPool<br><i>连接池管理</i>]
         D --> G[TaskManager<br><i>任务管理器</i>]
         D --> H[TLSManager<br><i>TLS证书管理</i>]
+        D --> OO[RootServerManager<br><i>根服务器管理</i>]
     end
 
     subgraph QueryFlow ["查询流程"]
@@ -106,6 +108,7 @@ graph TD
 
         J --> L[QueryClient<br><i>统一查询客户端</i>]
         K --> L
+        K --> OO
         L --> F
     end
 
@@ -152,6 +155,15 @@ graph TD
         FF --> JJ[唯一ID<br><i>请求标识</i>]
     end
 
+    subgraph RootServerSystem ["根服务器系统"]
+        OO --> PP[IPv4根服务器池<br><i>13个根服务器</i>]
+        OO --> QQ[IPv6根服务器池<br><i>13个根服务器</i>]
+        OO --> RR[速度排序<br><i>基于UDP:53测试</i>]
+
+        RR --> SS[最优服务器选择<br><i>IPv4/IPv6混合</i>]
+        OO --> TT[周期性重排序<br><i>5分钟间隔</i>]
+    end
+
     subgraph DDR ["DDR功能"]
         H --> KK[DDRSettings<br><i>DDR配置</i>]
         KK --> LL[SVCB记录<br><i>服务发现</i>]
@@ -168,6 +180,7 @@ graph TD
     classDef cache fill:#fff0e6,stroke:#333;
     classDef client fill:#f0e6ff,stroke:#333;
     classDef support fill:#e6ffff,stroke:#333;
+    classDef rootserver fill:#f0fff0,stroke:#333;
 
     class ServerCore core;
     class Managers manager;
@@ -175,6 +188,7 @@ graph TD
     class CacheSystem cache;
     class SecureClients client;
     class Support support;
+    class RootServerSystem rootserver;
 ```
 
 ---

--- a/main.go
+++ b/main.go
@@ -81,7 +81,7 @@ const (
 	SpeedDebounceInterval = 10 * time.Second
 
 	// Root Server Management
-	RootServerSortInterval = 300 * time.Second
+	RootServerSortInterval = 900 * time.Second
 
 	// Connection Lifecycle
 	SecureIdleTimeout  = 300 * time.Second

--- a/main.go
+++ b/main.go
@@ -1045,7 +1045,7 @@ func GenerateExampleConfig() string {
 				{
 					Type:    "A",
 					Content: "127.0.0.1",
-					TTL:     300,
+					TTL:     DefaultCacheTTL,
 				},
 			},
 		},
@@ -1055,7 +1055,7 @@ func GenerateExampleConfig() string {
 				{
 					Type:    "AAAA",
 					Content: "::1",
-					TTL:     300,
+					TTL:     DefaultCacheTTL,
 				},
 			},
 		},
@@ -1064,22 +1064,22 @@ func GenerateExampleConfig() string {
 	config.SpeedTest = []SpeedTestMethod{
 		{
 			Type:    "icmp",
-			Timeout: 1000,
+			Timeout: int(DefaultSpeedTimeout.Milliseconds()),
 		},
 		{
 			Type:    "tcp",
 			Port:    "443",
-			Timeout: 1000,
+			Timeout: int(DefaultSpeedTimeout.Milliseconds()),
 		},
 		{
 			Type:    "tcp",
 			Port:    "80",
-			Timeout: 1000,
+			Timeout: int(DefaultSpeedTimeout.Milliseconds()),
 		},
 		{
 			Type:    "udp",
 			Port:    "53",
-			Timeout: 1000,
+			Timeout: int(DefaultSpeedTimeout.Milliseconds()),
 		},
 	}
 
@@ -5880,7 +5880,7 @@ func NewRootServerManager(config ServerConfig) *RootServerManager {
 		{
 			Type:    "udp",
 			Port:    DefaultDNSPort,
-			Timeout: int(DefaultSpeedTimeout),
+			Timeout: int(DefaultSpeedTimeout.Milliseconds()),
 		},
 	}
 

--- a/main.go
+++ b/main.go
@@ -6079,12 +6079,18 @@ func sortBySpeedResult(servers []string, results map[string]*SpeedResult) []stri
 	return sorted
 }
 
+import (
+	"net"
+	"strings"
+)
+
 func extractIPFromServer(server string) string {
-	server = strings.Trim(server, "[]")
-	if idx := strings.LastIndex(server, ":"); idx != -1 {
-		return server[:idx]
+	host, _, err := net.SplitHostPort(server)
+	if err != nil {
+		// If server does not contain a port, return as is (could be just an IP)
+		return server
 	}
-	return server
+	return host
 }
 
 // =============================================================================

--- a/main.go
+++ b/main.go
@@ -6079,11 +6079,6 @@ func sortBySpeedResult(servers []string, results map[string]*SpeedResult) []stri
 	return sorted
 }
 
-import (
-	"net"
-	"strings"
-)
-
 func extractIPFromServer(server string) string {
 	host, _, err := net.SplitHostPort(server)
 	if err != nil {


### PR DESCRIPTION
## Sourcery 总结

通过引入一个 RootServerManager 来替换静态根服务器列表，实现动态根服务器管理。该管理器负责测量延迟、对服务器进行排序，并定期更新最佳选择。

新功能：
- 添加 RootServerManager 以维护 IPv4 和 IPv6 根服务器并测量它们的延迟
- 将 DNSServer 中的静态根服务器数组替换为 RootServerManager 初始化
- 实现根服务器按延迟进行周期性后台排序
- 更新 GetRootServers 以根据 IPv4/IPv6 配置获取最佳服务器

改进：
- 移除 DNSServer 中硬编码的 rootServersV4 和 rootServersV6 切片，转而采用动态选择

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

通过添加 RootServerManager 引入动态根服务器管理以取代静态列表，测量并按延迟对服务器进行排序，定期刷新排名，并更新 DNSServer 以根据 IPv4/IPv6 配置选择最优服务器。

新功能:
- 引入 RootServerManager，动态管理 IPv4 和 IPv6 根服务器并进行延迟测量
- 实现根据测量的延迟对根服务器进行周期性后台排序
- 将 DNSServer 中的静态根服务器列表替换为通过 RootServerManager 进行动态选择
- 增强 GetRootServers，根据 IPv4/IPv6 配置返回最优服务器

改进:
- 将默认速度测试超时时间从 1 秒减少到 250 毫秒
- 移除 DNSServer 中硬编码的根服务器切片，并通过 RootServerManager 整合初始化

文档:
- 在 README 中记录智能根服务器管理并更新架构图

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

引入一个动态的 RootServerManager，以替代硬编码的根服务器列表，实现基于延迟的选择和周期性的后台排序，同时调整相关的超时和默认 TTL，并更新文档以反映新的根服务器管理系统。

新功能：
- 添加 RootServerManager 以维护 IPv4 和 IPv6 根服务器，测量它们的延迟，并按速度对其进行排序
- 在 DNSServer 中用 RootServerManager 初始化替换静态根服务器数组，并使用 GetOptimalRootServers 进行服务器选择
- 启动一个周期性后台任务，在运行时重新排序根服务器

改进：
- 将 DefaultSpeedTimeout 从 1 秒减少到 250 毫秒，并更新示例配置以使用此超时
- 在生成的示例配置中使用 DefaultCacheTTL 而不是硬编码值

文档：
- 更新 README 以描述智能根服务器管理，并在架构图中添加 RootServerManager 节点

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dynamic RootServerManager to replace hardcoded root server lists with latency-based selection and periodic background sorting, adjust related timeouts and default TTLs, and update documentation to reflect the new root server management system.

New Features:
- Add RootServerManager to maintain IPv4 and IPv6 root servers, measure their latency, and sort them by speed
- Replace static root server arrays in DNSServer with RootServerManager initialization and use GetOptimalRootServers for server selection
- Start a periodic background task to re-sort root servers at runtime

Enhancements:
- Reduce DefaultSpeedTimeout from 1 second to 250 milliseconds and update example config to use this timeout
- Use DefaultCacheTTL in generated example configuration instead of hardcoded values

Documentation:
- Update README to describe intelligent root server management and add RootServerManager nodes in architecture diagram

</details>

</details>

</details>