### PR TITLE
feat: Implement latency-aware root server selection

### DIFF
--- a/main.go
+++ b/main.go
@@ -589,6 +589,10 @@ type ResourceManager struct {
 	}
 }
 
+// =============================================================================
+// Types - Config Management
+// =============================================================================
+
 type ConfigManager struct{}
 
 // =============================================================================
@@ -4347,6 +4351,7 @@ func (s *DNSServer) GetRootServers() []string {
 	for i, server := range serversWithLatency {
 		servers[i] = server.Server
 	}
+
 	return servers
 }
 

--- a/main.go
+++ b/main.go
@@ -599,8 +599,8 @@ type RootServerManager struct {
 	serversV4    []string
 	serversV6    []string
 	speedTester  *SpeedTester
-	sortedV4     []RootServerWithLatency // 存储包含延迟信息的 IPv4 服务器
-	sortedV6     []RootServerWithLatency // 存储包含延迟信息的 IPv6 服务器
+	sortedV4     []RootServerWithLatency
+	sortedV6     []RootServerWithLatency
 	lastSortTime time.Time
 	mu           sync.RWMutex
 }

--- a/main.go
+++ b/main.go
@@ -147,6 +147,7 @@ const (
 
 	// SpeedTest Configuration
 	DefaultSpeedConcurrency = 4
+	UnreachableLatency      = 9999 * time.Millisecond
 
 	// Default Values
 	DefaultLogLevel = "info"
@@ -4150,12 +4151,10 @@ func (s *DNSServer) FilterRecordsByPolicy(records []dns.RR, ctx FilterContext) [
 		case *dns.AAAA:
 			ip = record.AAAA
 		default:
-			// 非 IP 记录直接保留
 			filtered = append(filtered, rr)
 			continue
 		}
 
-		// IP 记录根据策略过滤
 		isTrusted := s.ipFilter.IsTrustedIP(ip)
 		shouldKeep := (ctx.Policy == "trusted_only" && isTrusted) ||
 			(ctx.Policy == "untrusted_only" && !isTrusted)
@@ -4344,7 +4343,6 @@ func (s *DNSServer) ResolveNSAddressesConcurrent(ctx context.Context, nsRecords 
 	return allAddresses
 }
 
-// GetRootServers 返回所有根服务器地址列表（兼容旧接口）
 func (s *DNSServer) GetRootServers() []string {
 	serversWithLatency := s.rootServerManager.GetOptimalRootServers(s.config.Server.Features.IPv6)
 	servers := make([]string, len(serversWithLatency))
@@ -5969,7 +5967,7 @@ func NewRootServerManager(config ServerConfig) *RootServerManager {
 	for i, server := range rsm.serversV4 {
 		rsm.sortedV4[i] = RootServerWithLatency{
 			Server:    server,
-			Latency:   9999 * time.Millisecond,
+			Latency:   UnreachableLatency,
 			Reachable: false,
 		}
 	}
@@ -5977,7 +5975,7 @@ func NewRootServerManager(config ServerConfig) *RootServerManager {
 	for i, server := range rsm.serversV6 {
 		rsm.sortedV6[i] = RootServerWithLatency{
 			Server:    server,
-			Latency:   9999 * time.Millisecond,
+			Latency:   UnreachableLatency,
 			Reachable: false,
 		}
 	}
@@ -6059,7 +6057,7 @@ func SortBySpeedResultWithLatency(servers []string, results map[string]*SpeedRes
 		} else {
 			serverList[i] = RootServerWithLatency{
 				Server:    server,
-				Latency:   9999 * time.Millisecond,
+				Latency:   UnreachableLatency,
 				Reachable: false,
 			}
 		}

--- a/main.go
+++ b/main.go
@@ -147,7 +147,7 @@ const (
 
 	// SpeedTest Configuration
 	DefaultSpeedConcurrency = 4
-	UnreachableLatency      = 9999 * time.Millisecond
+	UnreachableLatency      = 10 * time.Second
 
 	// Default Values
 	DefaultLogLevel = "info"


### PR DESCRIPTION
## Sourcery 总结

通过测量每个服务器的延迟和可达性来改进根服务器选择，重构排序逻辑以使用这些指标，并保持现有接口的向后兼容性。

新功能：
- 引入 `RootServerWithLatency` 结构体，用于跟踪每个服务器的延迟和可达性
- 扩展根服务器测速，以包含 ICMP 和 TCP 方法

改进：
- 重构 `RootServerManager`，以根据延迟和可达性排序和选择服务器
- 更新 `GetOptimalRootServers` 以返回感知延迟的服务器列表，并保持 `GetRootServers` 的向后兼容性
- 重命名并整合辅助函数 (`ExtractIPsFromServers`, `SortBySpeedResultWithLatency`, `SortServersBySpeed`)

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

通过引入延迟感知的排序并增强速度测试方法，改进根服务器选择。

新功能：
- 添加 `RootServerWithLatency` 类型，用于捕获服务器地址、延迟和可达性状态

改进：
- 重构 `RootServerManager` 以返回 `RootServerWithLatency` 切片而不是普通的字符串
- 扩展 DNS 速度测试配置，除了 UDP 外，还包括 ICMP 和 TCP 探测
- 使用不可达的占位符初始化已排序的服务器列表，以获得更准确的初始状态
- 将内部的 `sortServersBySpeed` 和 `sortBySpeedResult` 替换为导出的 `SortServersBySpeed` 和 `SortBySpeedResultWithLatency` 函数

杂项：
- 将辅助函数 `extractIPFromServer` 和 `extractIPsFromServers` 重命名为导出的 `ExtractIPFromServer` 和 `ExtractIPsFromServers`
- 在 `DNSServer.GetRootServers` 中保持向后兼容性，通过将新结构映射到旧的字符串切片

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve root server selection by introducing latency-aware sorting and enhancing speed test methods.

New Features:
- Add RootServerWithLatency type to capture server address, latency, and reachability status

Enhancements:
- Refactor RootServerManager to return slices of RootServerWithLatency instead of plain strings
- Expand DNS speed test configuration to include ICMP and TCP probes alongside UDP
- Initialize sorted server lists with unreachable placeholders for more accurate initial state
- Replace internal sortServersBySpeed and sortBySpeedResult with exported SortServersBySpeed and SortBySpeedResultWithLatency functions

Chores:
- Rename extractIPFromServer and extractIPsFromServers helpers to exported ExtractIPFromServer and ExtractIPsFromServers
- Maintain backward compatibility in DNSServer.GetRootServers by mapping new structures to legacy string slices

</details>

</details>