### PR TITLE
feat: Add version display and build-time metadata

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,8 +19,11 @@ ZJDNS is a high-performance recursive DNS server written in Go that supports:
 
 ### Building
 ```bash
-# Build the binary
-go build -o zjdns -trimpath -ldflags "-s -w -buildid="
+# Build the binary with version info
+VERSION=$(git describe --tags --always 2>/dev/null || echo "1.0.0")
+COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "dev")
+BUILD_TIME=$(date -u '+%Y-%m-%d_%H:%M:%S')
+go build -o zjdns -trimpath -ldflags "-s -w -buildid= -X main.Version=${VERSION} -X main.CommitHash=${COMMIT} -X main.BuildTime=${BUILD_TIME}"
 
 # Build for production (uses Docker multi-stage build)
 docker build -t zjdns .

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,9 @@ ENV \
 RUN \
     wget "https://curl.se/ca/cacert.pem" \
     && go mod tidy \
-    && go build -o zjdns -trimpath -ldflags "-s -w -buildid="
+    && COMMIT_SHA=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown") \
+    && BUILD_TIME=$(date -u '+%Y-%m-%d %H:%M:%S UTC') \
+    && go build -o zjdns -trimpath -ldflags "-s -w -buildid= -X main.CommitHash=${COMMIT_SHA} -X main.BuildTime=${BUILD_TIME}"
 
 FROM scratch AS rebase_zjdns
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,9 @@ ENV \
 RUN \
     wget "https://curl.se/ca/cacert.pem" \
     && go mod tidy \
+    && BUILD_TIME=$(date -u '+%Y-%m-%d_%H:%M:%S_UTC') \
     && COMMIT_SHA=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown") \
-    && BUILD_TIME=$(date -u '+%Y-%m-%d %H:%M:%S UTC') \
-    && go build -o zjdns -trimpath -ldflags "-s -w -buildid= -X main.CommitHash=${COMMIT_SHA} -X main.BuildTime=${BUILD_TIME}"
+    && go build -o zjdns -trimpath -ldflags "-s -w -buildid= -X main.BuildTime=${BUILD_TIME} -X main.CommitHash=${COMMIT_SHA}"
 
 FROM scratch AS rebase_zjdns
 

--- a/main.go
+++ b/main.go
@@ -40,6 +40,22 @@ import (
 )
 
 // =============================================================================
+// Version Information
+// =============================================================================
+
+// These variables are set at build time using ldflags
+var (
+	Version    = "1.0.0" // Default version for development
+	CommitHash = "dev"   // Git commit hash
+	BuildTime  = ""      // Build timestamp
+)
+
+// GetVersion returns the full version string in format: {Version}-ZHIJIE-{CommitHash}
+func GetVersion() string {
+	return fmt.Sprintf("%s-ZHIJIE-%s", Version, CommitHash)
+}
+
+// =============================================================================
 // Constants - Network & Protocol
 // =============================================================================
 
@@ -5777,19 +5793,32 @@ func CloseWithLog(c Closeable, name string) {
 func main() {
 	var configFile string
 	var generateConfig bool
+	var showVersion bool
 
 	flag.StringVar(&configFile, "config", "", "Configuration file path (JSON format)")
 	flag.BoolVar(&generateConfig, "generate-config", false, "Generate example configuration file")
+	flag.BoolVar(&showVersion, "version", false, "Show version information and exit")
 
 	flag.Usage = func() {
-		fmt.Fprintf(os.Stderr, "ZJDNS Server\n\n")
+		fmt.Fprintf(os.Stderr, "ZJDNS Server - High Performance Recursive DNS Server\n\n")
+		fmt.Fprintf(os.Stderr, "Version: %s\n\n", GetVersion())
 		fmt.Fprintf(os.Stderr, "Usage:\n")
 		fmt.Fprintf(os.Stderr, "  %s -config <config file>     # Start with config file\n", os.Args[0])
 		fmt.Fprintf(os.Stderr, "  %s -generate-config          # Generate example config\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "  %s -version                  # Show version information\n", os.Args[0])
 		fmt.Fprintf(os.Stderr, "  %s                            # Start with default config\n\n", os.Args[0])
 	}
 
 	flag.Parse()
+
+	if showVersion {
+		fmt.Printf("ZJDNS Server\n")
+		fmt.Printf("Version: %s\n", GetVersion())
+		if BuildTime != "" {
+			fmt.Printf("Built: %s\n", BuildTime)
+		}
+		return
+	}
 
 	if generateConfig {
 		fmt.Println(GenerateExampleConfig())

--- a/main.go
+++ b/main.go
@@ -4990,7 +4990,7 @@ func (s *DNSServer) Start() error {
 
 	errChan := make(chan error, serverCount)
 
-	LogInfo("Starting ZJDNS Server")
+	LogInfo("Starting ZJDNS Server v%s", GetVersion())
 	LogInfo("Listening port: %s", s.config.Server.Port)
 
 	s.DisplayInfo()

--- a/main.go
+++ b/main.go
@@ -1818,6 +1818,7 @@ func (qc *QueryClient) ExecuteDoHQuery(ctx context.Context, msg *dns.Msg, server
 	}
 
 	httpReq.Header.Set("Accept", "application/dns-message")
+	httpReq.Header.Set("User-Agent", "")
 
 	httpResp, err := httpClient.Do(httpReq)
 	if err != nil {


### PR DESCRIPTION
## Sourcery 总结

实现版本显示功能，并支持构建时注入版本元数据。

新功能:
- 引入 Version、CommitHash 和 BuildTime 变量，通过 ldflags 设置，并添加 GetVersion 函数
- 添加 --version 标志，用于打印服务器版本、提交哈希和构建时间戳

改进:
- 在启动日志和使用帮助输出中包含版本信息

构建:
- 修改 Dockerfile 构建步骤，使用 ldflags 注入 BuildTime 和 CommitHash

文档:
- 更新 CLAUDE.md 中的构建说明，通过 ldflags 传递版本元数据

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement version display functionality with build-time injectable version metadata.

New Features:
- Introduce Version, CommitHash, and BuildTime variables set via ldflags and a GetVersion function
- Add a --version flag to print the server version, commit hash, and build timestamp

Enhancements:
- Include version info in startup logs and usage help output

Build:
- Modify Dockerfile build step to inject BuildTime and CommitHash using ldflags

Documentation:
- Update build instructions in CLAUDE.md to pass version metadata via ldflags

</details>